### PR TITLE
feat: Added buildView utility for declaring filters through view relations; resolves #47

### DIFF
--- a/.changeset/small-masks-cheer.md
+++ b/.changeset/small-masks-cheer.md
@@ -1,0 +1,6 @@
+---
+"slonik-trpc": minor
+---
+
+Added buildView utilty for building easier filters.
+Backwards compatible change but deprecated older method for creating filters.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,43 @@ Add the package and its peer dependencies to your project
 yarn add slonik-trpc slonik zod
 ```
 
+### List of features
+
+- [x] Declarative [filtering API](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/filtering) (filter creation utils included!)
+  - [x] Automatic support for `AND`, `NOT`, `OR` in all the filters
+  - [x] Ability to add [authorization filters](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/authorization) based on user auth context.
+- [x] [Select the fields](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/overfetching) you need, to avoid the overfetching problem.
+  - [x] Fully type-safe, only selected fields are returned in the types. If no selects are specified, every field is returned.
+- [x] Runtime validation of input (completely safe against unsanitized inputs).
+- [x] Optional runtime validation of output (Your zod types can be executed against your result, including transforming the output fields with zod transformers).
+- [x] [Virtual field](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/virtual-columns) declaration in typescript (fully type-safe + with async support).
+- [x] [Declarative sorting](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/sorting) capabilities, with support for custom SQL sorting expressions
+- [x] [DISTINCT ON](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/distinct) support with PostgreSQL, for all sortable columns
+- [x] [Offset-based pagination](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/pagination).
+- [x] [Cursor-based pagination](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/cursor-pagination).
+  - [x] Reverse page support
+- [x] [Plugins](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/plugins)
+
+### Requirements
+
+TypeScript 4.5+
+Slonik 33+
+Zod 3+
+
+
 ## Basic Usage
 
 Create a view for your table/relation you want to query, using only the FROM clause part of a SQL query.
 
 ```ts
-import { buildView } from 'slonik-trpc';
+import { buildView, sql } from 'slonik-trpc';
 
 const postsView = buildView`
 FROM users
 LEFT JOIN posts
     ON posts.author = users.id`
+.addStringFilter('posts.title')
+.addInArrayFilter('id', () => sql.fragment`posts.id`, 'numeric')
 ```
 
 Then write the SELECT part with the fields you want to make queryable in the API, and type them with zod.
@@ -62,34 +88,18 @@ Query this loader/API by selecting just the fields you need.
 // This array is type-safe, only having "id", "text", and "age" fields
 const posts = await loader.load({
     select: ["id", "text", "age"],
+    where: {
+        OR: [{
+            "posts.title": "Lorem Ipsum",
+        }, {
+            "posts.id": [3, 4],
+        }]
+    },
     take: 200,
 });
 ```
 
 Read on for more advanced usage, including how to use sorting, filtering, cursor pagination, authorization checks, creating a tRPC API and more.
-
-### List of features
-
-- [x] Declarative [filtering API](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/filtering) (filter creation utils included!)
-  - [x] Automatic support for `AND`, `NOT`, `OR` in all the filters
-  - [x] Ability to add [authorization filters](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/authorization) based on user auth context.
-- [x] [Select the fields](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/overfetching) you need, to avoid the overfetching problem.
-  - [x] Fully type-safe, only selected fields are returned in the types. If no selects are specified, every field is returned.
-- [x] Runtime validation of input (completely safe against unsanitized inputs).
-- [x] Optional runtime validation of output (Your zod types can be executed against your result, including transforming the output fields with zod transformers).
-- [x] [Virtual field](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/virtual-columns) declaration in typescript (fully type-safe + with async support).
-- [x] [Declarative sorting](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/sorting) capabilities, with support for custom SQL sorting expressions
-- [x] [DISTINCT ON](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/distinct) support with PostgreSQL, for all sortable columns
-- [x] [Offset-based pagination](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/pagination).
-- [x] [Cursor-based pagination](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/cursor-pagination).
-  - [x] Reverse page support
-- [x] [Plugins](https://ardsh.github.io/slonik-trpc/docs/usage-main-features/plugins)
-
-### Requirements
-
-TypeScript 4.5+
-Slonik 33+
-Zod 3+
 
 ### Demo
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,38 @@ const specificUsers = await filtersLoader.load({
 
 However, these too can be disabled (when calling `getLoadArgs`), and it is recommended to do so for the `OR` filter, which is often computationally expensive and shouldn't be allowed on a public API.
 
+### Declaring filters through View Relations
+
+An easier way to declare and reuse the above filters is by using `buildView`
+
+```ts
+buildView`FROM users`
+    .addInArrayFilter('users.id')
+    .addStringFilter(['users.name', 'users.profession'])
+    .addComparisonFilter('postsCount', (table) => sql.fragment`${table}."authoredPosts"`)
+    .addComparisonFilter('users.created_at')
+    .addGenericFilter('ID', (value: string) => sql.fragment`users.id = ${value}`)
+    .addBooleanFilter('isGmail', (table) => sql.fragment`${table}.email ILIKE '%gmail.com'`)
+```
+
+This is the equivalent of the above. It allows an extensive filtering API through those helper functions like `addStringFilter` and `addInArrayFilter`
+
+```ts
+where: {
+    ID: 'abc',
+    isGmail: true,
+    postsCount: {
+        _gte: 30,
+    },
+    "users.profession": {
+        _ilike: '%engineer%',
+    },
+    "users.created_at": {
+        _lt: '2020-01-01',
+    },
+}
+```
+
 ### Authorization
 
 For authorization checks, use the `constraints` option to add hardcoded conditions to the query, based on the context.

--- a/docs/docs/usage-main-features/classic-filtering.md
+++ b/docs/docs/usage-main-features/classic-filtering.md
@@ -1,0 +1,212 @@
+---
+sidebar_position: 22
+---
+
+# Classic Filtering method (DEPRECATED)
+
+:::warning DEPRECATION
+This method has been deprecated. Use `buildView` to create filters instead.
+:::
+
+Filtering in slonik-trpc allows you to specify which data you want to receive from the database. Once you declare the filters, complex combinations using AND, OR and NOT will be available automatically.
+
+### Simple filter
+
+Here is an example of how to build a simple filter:
+
+```ts
+createFilter<Context>()({
+    id: z.string(),
+}, {
+    id: (value) => sql.fragment`users.id = ${value}`
+});
+```
+
+This filter will accept a string as an `id`, and add a condition to the main query.
+So passing the following `where` object:
+
+```ts
+where: {
+    id: 5
+}
+```
+
+Will result in a condition like
+
+```sql
+WHERE users.id = 5
+```
+
+Since we're using zod, it's not possible to pass anything but a string in that filter.
+
+Suppose we want to query multiple users though. The API builder automatically adds `AND`, `OR` and `NOT` clauses, so this is possible
+
+```ts
+where: {
+    OR: [{
+        id: 5,
+    }, {
+        id: 6
+    }]
+}
+```
+
+In SQL it will correspond to this condition (though you don't have to worry about that)
+
+```sql
+WHERE ((users.id = 5) OR (users.id = 6))
+```
+
+### Filtering with arrays of id
+
+To make it easier to query multiple IDs at once, you can use the `arrayFilter` utility function. Here is an example of how to use it:
+
+```ts
+createFilter<Context>()({
+    ids: z.array(z.string()),
+}, {
+    ids: (values) => sql.fragment`users.id = ANY(${sql.array(values, 'text')})`
+});
+```
+
+Using the `arrayFilter` utility for this kind of filter makes it easier to declare. For example:
+
+```ts
+createFilter<Context>()({
+    ids: arrayStringFilterType,
+}, {
+    ids: (values) => arrayFilter(values, sql.fragment`users.id`)
+});
+```
+
+Then, to use the filter, you can pass an `ids` array to the `where` object:
+
+```ts
+where: {
+    ids: [3, 4, 5]
+}
+```
+
+This will produce an SQL condition like the following:
+
+```sql
+WHERE users.id = ANY([3,4,5]::text[])
+```
+
+### Using the booleanFilter utility
+
+The `booleanFilter` utility takes in a fragment and applies it if the input is true. It applies the reverse if the input is `false`, and doesn't apply anything if the input is `null`/`undefined`.
+
+```ts
+const filters = createFilters()({
+    isGmail: z.boolean(),
+}, {
+    isGmail: (value) => booleanFilter(value, `users.email ILIKE '%gmail.com'`),
+});
+```
+
+To use the filter, you can pass an `isGmail` value to the `where` object:
+
+```ts
+const nonGmailUsers = await filtersLoader.load({
+    where: {
+        isGmail: false,
+    }
+});
+```
+
+This will return only users that have their email ending in gmail.com.
+
+The equivalent SQL would be
+
+```sql
+WHERE NOT(email ILIKE '%gmail.com')
+```
+
+### Merging filters
+
+A good method of organization might be to declare filters based on the tables they access, e.g. `users` filters, `posts` filters, etc., then merge them at the end.
+
+
+```ts
+const userFilters = createFilters()({
+    isGmail: z.boolean(),
+    userIds: arrayStringFilterType,
+}, {
+    userIds: (values) => arrayFilter(values, sql.fragment`users.id`),
+    isGmail: (value) => booleanFilter(value, `users.email ILIKE '%gmail.com'`),
+});
+
+const postFilters = createFilters()({
+    postIds: arrayStringFilterType,
+    longPost: z.boolean(),
+}, {
+    postIds: (values) => arrayFilter(values, sql.fragment`posts.id`),
+    longPost: (value) => booleanFilter(value, sql.fragment`LENGTH(posts.content) > 500`),
+});
+
+// merge filters
+const filters = mergeFilters([userFilters, postFilters]);
+```
+
+Now, the filters object has all the filters that are declared in the userFilters and postFilters objects. You can use the filters object in the makeQueryLoader function:
+
+```ts
+import { mergeFilters } from 'slonik-trpc/utils';
+
+const postsLoader = makeQueryLoader({
+    db,
+    query: {
+        select: sql.type(zodType)`SELECT posts.*, users.first_name, users.last_name`,
+        from: sql.fragment`FROM posts LEFT JOIN users ON users.id = posts.author_id`,
+    },
+    filters,
+})
+```
+
+To use the filters, pass the where object to the load() function:
+
+```ts
+const posts = await postsLoader.load({
+  where: {
+    OR: [{
+      userIds: [1, 2, 3],
+    }, {
+      longPost: true,
+    }]
+  }
+});
+```
+
+This will produce an SQL query like the following:
+
+```sql
+SELECT *
+FROM posts
+LEFT JOIN users ON users.id = posts.user_id
+WHERE (users.id = ANY([1,2,3]::text[]) OR LENGTH(posts.content) > 500)
+```
+
+:::tip
+The mergeFilters function helps with type safety, just like createFilters. They're not necessary if you specify the filters directly as options in the makeQueryLoader options, but that doesn't allow easy reusability.
+:::
+
+## Usage with tRPC
+
+It is recommended to disable OR filters, because they can be computationally expensive.
+When calling the getLoadArgs function, specify the disabled filters:
+
+```ts
+getPosts: publicProcedure
+    .input(postsLoader.getLoadArgs({
+        disabledFilters: {
+            OR: true,
+        }
+    }))
+    .query(({ input, ctx }) => {
+        return postsLoader.loadPagination({
+            ...input,
+            ctx,
+        });
+    }),
+```

--- a/docs/docs/usage-main-features/filtering.md
+++ b/docs/docs/usage-main-features/filtering.md
@@ -113,7 +113,7 @@ WHERE NOT(email ILIKE '%gmail.com')
 
 ### JSON filters
 
-The `addJsonContainsFilter` utility is designed to filter records based on the contents of a JSONB column in your database. It uses PostgreSQL's `@>` operator to check if the JSONB column contains a specific structure or value.
+The `addJsonContainsFilter` utility is designed to filter records based on the contents of a JSONB column in your database. It uses [PostgreSQL's `@>` operator](https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING) to check if the JSONB column contains a specific structure or value.
 
 ```ts
 // Adding the JSON contains filter

--- a/docs/docs/usage-main-features/usage.md
+++ b/docs/docs/usage-main-features/usage.md
@@ -13,8 +13,7 @@ You can look at the [minimal-example playground](https://stackblitz.com/github/a
 Create a file at `src/postsLoader.ts`:
 
 ```ts title="postsLoader.ts"
-import { makeQueryLoader } from 'slonik-trpc';
-import { sql } from 'slonik';
+import { makeQueryLoader, buildView, sql } from 'slonik-trpc';
 
 const postsQuery = {
     select: sql.type(z.object({
@@ -27,7 +26,7 @@ const postsQuery = {
         users.first_name || ' ' || users.last_name AS author,
         posts.title,
         posts.date`,
-    from: sql.fragment`FROM posts
+    view: buildView`FROM posts
     LEFT JOIN users
         ON users.id = posts.author_id`
 };

--- a/src/core/__tests__/__snapshots__/makeQuery.test.ts.snap
+++ b/src/core/__tests__/__snapshots__/makeQuery.test.ts.snap
@@ -100,21 +100,6 @@ exports[`withQueryLoader Allows using sql fragment for specifying sortable colum
 ]
 `;
 
-exports[`withQueryLoader Doesn't allow invalid types 1`] = `
-"[
-  {
-    "code": "invalid_type",
-    "expected": "number",
-    "received": "string",
-    "path": [
-      "where",
-      "id"
-    ],
-    "message": "Expected number, received string"
-  }
-]"
-`;
-
 exports[`withQueryLoader Doesn't allow sorting by unallowed columns 1`] = `
 "[
   {

--- a/src/core/__tests__/buildView.test.ts
+++ b/src/core/__tests__/buildView.test.ts
@@ -59,7 +59,7 @@ it('Allows building a view from a string', async () => {
 
 it("Doesn't allow arrays with custom filters", async () => {
   expect(() => buildView`FROM users`
-    .addBooleanFilter(['long_email', 'something_else'], (table) => sql.fragment`LENGTH(${table}.email) > 10`)
+    .addBooleanFilter(['long_email', 'something_else'], (table) => sql.fragment`LENGTH(${table._main}.email) > 10`)
   ).toThrow("If you specify a mapper function you cannot have multiple filter keys");
 });
 it("Allows specifying multiple keys", async () => {

--- a/src/core/__tests__/buildView.test.ts
+++ b/src/core/__tests__/buildView.test.ts
@@ -49,7 +49,10 @@ it('Allows building a view from a string', async () => {
           name: 'Bob'
         }
       ]
-    }
+    },
+    options: {
+      orEnabled: true,
+    },
   });
   const data = await db.any(
     sql.unsafe`SELECT * ${usersView} ${whereFragment}`
@@ -147,6 +150,9 @@ it("Allows specifying composite tables", async () => {
       }, {
         "combined.users.last_name": 'abc',
       }]
+    },
+    options: {
+      orEnabled: true,
     }
   });
   expect(composite.sql).toContain(`"combined"."count" > `);
@@ -207,6 +213,9 @@ describe("Filters", () => {
         }, {
           ID: '123',
         }]
+      },
+      options: {
+        orEnabled: true,
       }
     });
     expect(query.sql).toContain(`"users".id = ANY(`);

--- a/src/core/__tests__/buildView.test.ts
+++ b/src/core/__tests__/buildView.test.ts
@@ -1,0 +1,220 @@
+import { sql } from 'slonik'
+import { makeQueryTester } from './makeQueryTester';
+import { buildView } from '../buildView'
+import { makeQueryLoader } from '../makeQueryLoader';
+
+const { db } = makeQueryTester('buildView')
+
+it('Allows building a view from a string', async () => {
+  const usersView = buildView`FROM users`
+    .addFilters({
+      test: (value: string) => sql.fragment`email = ${value}`,
+      name: (value: string) => sql.fragment`first_name = ${value}`
+    })
+    .addStringFilter('users.last_name')
+    .addBooleanFilter('long_email', (table) => sql.fragment`LENGTH(${table}.email) > 10`)
+
+  const compositeView = buildView`FROM users
+    LEFT JOIN test_table_bar ON test_table_bar.uid = users.id`.addFilters(
+    usersView.getFilters({
+      table: 'users',
+      include: ['long_email'],
+    })
+  ).setFilterPreprocess((filters) => {
+    filters['users.long_email'] = true;
+    return filters;
+  })
+  expect(
+    (
+      await compositeView.getWhereFragment({
+        // Automatically adds long_email through preprocessor
+        where: {}
+      })
+    ).sql
+  ).toMatch('LENGTH("users".email) > 10')
+  const whereFragment = await usersView.getWhereFragment({
+    where: {
+      'users.last_name': {
+        _ilike: '%e%'
+      },
+      OR: [
+        {
+          name: 'Haskell'
+        },
+        {
+          name: 'Bob'
+        }
+      ]
+    }
+  });
+  const data = await db.any(
+    sql.unsafe`SELECT * ${usersView} ${whereFragment}`
+  )
+  expect(data).toEqual([expect.anything(), expect.anything()])
+});
+
+it("Doesn't allow arrays with custom filters", async () => {
+  expect(() => buildView`FROM users`
+    .addBooleanFilter(['long_email', 'something_else'], (table) => sql.fragment`LENGTH(${table}.email) > 10`)
+  ).toThrow("If you specify a mapper function you cannot have multiple filter keys");
+});
+it("Allows specifying multiple keys", async () => {
+  const userView = buildView`FROM users`.addStringFilter(['email', 'first_name', 'last_name'])
+
+  const query = await userView.getWhereFragment({
+    where: {
+      last_name: 'buzz',
+      email: 'fizz',
+    }
+  });
+  expect(query.sql).toContain(`"last_name" = `);
+  expect(query.values).toEqual(['buzz', 'fizz']);
+});
+
+it("Cannot determine table for nonsensical views", async () => {
+  expect(() => buildView`SELECT * FROM users`).toThrow("First part of view must be FROM");
+  buildView`FROM (SELECT * FROM users)`
+});
+
+it("Allows specifying views in query loader", async () => {
+  const userView = buildView`FROM (SELECT * FROM users WHERE LENGTH(users."first_name") < 8) users`
+    .addStringFilter(['email', 'first_name', 'last_name'])
+
+  const loader = makeQueryLoader({
+    db,
+    query: {
+      select: sql.unsafe`SELECT *`,
+      view: userView,
+    }
+  })
+  const query = await loader.getQuery({
+    where: {
+      last_name: 'buzz',
+    }
+  });
+  expect(query.sql).toContain(`"last_name" = `);
+  expect(query.sql).toContain("LENGTH(users.\"first_name\") < 8");
+  expect(query.values).toEqual(['buzz']);
+
+  const data = await loader.load({
+    where: {
+      last_name: 'Dean',
+    }
+  });
+  expect(data).toEqual([expect.anything()]);
+});
+
+
+it("Allows specifying composite tables", async () => {
+  const userView = buildView`FROM users LEFT JOIN posts
+  ON posts.user_id = users.id`
+  .addStringFilter(['users.email', 'users.first_name', 'posts.text', 'users.last_name', 'posts.title'])
+  .setMainTable('users')
+
+  const query = await userView.getWhereFragment({
+    where: {
+      'users.last_name': 'buzz',
+      'users.email': 'fizz',
+      'posts.title': 'foo',
+    }
+  });
+  expect(query.sql).toContain(`"users"."last_name" = `);
+  expect(query.sql).toContain(`"users"."email" = `);
+  expect(query.sql).toContain(`"posts"."title" = `);
+
+  const compositeView = buildView`FROM (SELECT users.*, COUNT(posts.*)
+    FROM users LEFT JOIN posts
+  ON posts.user_id = users.id GROUP BY users.id) combined`.addFilters(
+    userView.getFilters({
+      table: 'combined',
+      exclude: ['posts.*'],
+    })
+  )
+  .addComparisonFilter('combined.count')
+  const composite = await compositeView.getWhereFragment({
+    where: {
+      OR: [{
+        'combined.count': {
+          _gt: 10,
+        },
+      }, {
+        "combined.users.last_name": 'abc',
+      }]
+    }
+  });
+  expect(composite.sql).toContain(`"combined"."count" > `);
+  expect(composite.sql).toContain(`"combined"."last_name" = `);
+
+  const filters = compositeView.getFilters();
+  expect(filters).toEqual({
+    'combined.count': expect.anything(),
+    'combined.users.email': expect.anything(),
+    'combined.users.first_name': expect.anything(),
+    'combined.users.last_name': expect.anything(),
+  });
+});
+
+describe("Filters", () => {
+  const userView = buildView`FROM users LEFT JOIN posts
+    ON posts.user_id = users.id`
+    .addStringFilter(['users.email', 'users.first_name', 'users.last_name', 'posts.title'])
+    .addGenericFilter('ID', (value: string) => sql.fragment`users.id = ${value}`)
+    .addInArrayFilter('users.id')
+    .addStringFilter(['users.name', 'users.profession'])
+    .addComparisonFilter('usersID', (table, value) => sql.fragment`${table}.id`)
+    .addComparisonFilter('postsCount', (table) => sql.fragment`${table}."authoredPosts"`)
+    .addComparisonFilter('users.created_at')
+    .addBooleanFilter('isGmail', (table) => sql.fragment`${table}.email ILIKE '%gmail.com'`)
+    .setMainTable('users')
+
+  it("Allows specifying generic filters", async () => {
+    const query = await userView.getWhereFragment({
+      where: {
+        NOT: {
+          ID: '123',
+        }
+      }
+    });
+    expect(query.sql).toContain(`users.id = `);
+  });
+  it("Allows specifying in array filters", async () => {
+    const query = await userView.getWhereFragment({
+      where: {
+        isGmail: true,
+        postsCount: {
+          _gte: 30,
+        },
+        "users.profession": {
+          _ilike: '%engineer%',
+        },
+        "users.created_at": {
+          _lt: '2020-01-01',
+        },
+        OR: [{
+          'users.id': ['123', '456'],
+        }, {
+          ID: '123',
+        }]
+      }
+    });
+    expect(query.sql).toContain(`"users"."id" = ANY(`);
+    expect(query.sql).toContain(`users.id = `);
+    expect(query.sql).toContain(`) OR (`);
+  });
+  it("Allows specifying comparison filters", async () => {
+    const query = await userView.getWhereFragment({
+      where: {
+        AND: [{
+          usersID: {
+            _gt: 10,
+          },
+        }, {
+          "posts.title": 'abc',
+        }]
+      }
+    });
+    expect(query.sql).toContain(`"users".id > `);
+    expect(query.sql).toContain(`"posts"."title" = `);
+    expect(query.sql).toContain(`) AND (`);
+  });
+});

--- a/src/core/__tests__/makeQuery.test.ts
+++ b/src/core/__tests__/makeQuery.test.ts
@@ -1,5 +1,4 @@
-import { makeQueryLoader, InferPayload, InferArgs } from '../../index';
-import { sql } from 'slonik';
+import { sql, makeQueryLoader, InferPayload, InferArgs } from '../../index';
 import { z } from 'zod';
 import { makeQueryTester } from './makeQueryTester';
 

--- a/src/core/__tests__/makeQuery.test.ts
+++ b/src/core/__tests__/makeQuery.test.ts
@@ -964,27 +964,6 @@ describe("withQueryLoader", () => {
         expectTypeOf(parsed.where).toEqualTypeOf<undefined>();
     });
 
-    it("Doesn't allow invalid types", async () => {
-        const loader = makeQueryLoader({
-            ...genericOptions,
-            selectableColumns: ["id", "uid"],
-            sortableColumns: {
-                id: "id",
-            }
-        });
-        const parser = loader.getLoadArgs({
-            sortableColumns: ["id"],
-        });
-        const where = {
-            id: 'invalidType',
-            largeIds: true,
-            someOtherField: null,
-        }
-        expect(() => parser.parse({
-            where,
-        })).toThrowErrorMatchingSnapshot();
-    });
-
     it("Doesn't allow sorting by unallowed columns", async () => {
         const loader = makeQueryLoader({
             ...genericOptions,

--- a/src/core/__tests__/makeQuery.test.ts
+++ b/src/core/__tests__/makeQuery.test.ts
@@ -945,10 +945,10 @@ describe("withQueryLoader", () => {
         expectTypeOf(parsed.select?.[0]).toEqualTypeOf<"id" | "value" | "asdf" | undefined>();
 
         expectTypeOf((parsed as InferArgs<typeof loader>).select?.[0]).toEqualTypeOf<"dummyField" | "id" | undefined>();
-        expectTypeOf(parsed.where).toMatchTypeOf<InferArgs<typeof loader>["where"] | undefined>();
-        expectTypeOf(parsed.orderBy).toMatchTypeOf<InferArgs<typeof loader>["orderBy"] | undefined>();
-        expectTypeOf(parsed.searchAfter).toMatchTypeOf<InferArgs<typeof loader>["searchAfter"] | undefined>();
-        expectTypeOf(parsed.selectGroups).toMatchTypeOf<InferArgs<typeof loader>["selectGroups"] | undefined>();
+        expectTypeOf(parsed.where).toMatchTypeOf<InferArgs<typeof loader>["where"]>();
+        expectTypeOf(parsed.orderBy).toMatchTypeOf<InferArgs<typeof loader>["orderBy"]>();
+        expectTypeOf(parsed.searchAfter).toMatchTypeOf<InferArgs<typeof loader>["searchAfter"]>();
+        expectTypeOf(parsed.selectGroups).toMatchTypeOf<InferArgs<typeof loader>["selectGroups"]>();
     });
 
     it("Doesn't allow filtering when no filters are specified", async () => {
@@ -970,6 +970,12 @@ describe("withQueryLoader", () => {
         expect(parser.parse({
             where: {
                 id: 3,
+                AND: [{
+                    id: 5,
+                }],
+                OR: [{
+                    blabla: true,
+                }],
             },
         })).toEqual({
             where: {},

--- a/src/core/__tests__/playground.test.ts
+++ b/src/core/__tests__/playground.test.ts
@@ -126,6 +126,9 @@ const filtersLoader = makeQueryLoader({
     db,
     filters,
     contextParser: testContext,
+    options: {
+        orFilterEnabled: true,
+    },
 });
 
 const gmailUsers = await filtersLoader.load({

--- a/src/core/buildView.ts
+++ b/src/core/buildView.ts
@@ -111,11 +111,11 @@ export type BuildView<
    */
   addStringFilter: <TKey extends Exclude<string, TFilterKey>>(
     field: TKey | TKey[],
-    name?: ((table: IdentifierSqlToken & {
+    name?: ((table: {
       [x in TAliases]: IdentifierSqlToken
     } & {
       [x: string]: IdentifierSqlToken
-    }, value?: z.infer<typeof stringFilterType>, allFilters?: any, ctx?: any) => SqlFragment)
+    }, value?: z.infer<typeof stringFilterType>, allFilters?: TFilter, ctx?: any) => SqlFragment)
   ) => BuildView<
     TFilter & { [x in TKey]?: z.infer<typeof stringFilterType> },
     keyof TFilter | TKey,
@@ -130,11 +130,11 @@ export type BuildView<
   addComparisonFilter: <TKey extends Exclude<string, TFilterKey>>(
     // Not adding allFilters + context in the interface until the API becomes more stable
     name: TKey | TKey[],
-    mapper?: ((table: IdentifierSqlToken & {
+    mapper?: ((table: {
       [x in TAliases]: IdentifierSqlToken
     } & {
       [x: string]: IdentifierSqlToken
-    }, value?: z.infer<typeof comparisonFilterType>, allFilters?: any, ctx?: any) => SqlFragment)
+    }, value?: z.infer<typeof comparisonFilterType>, allFilters?: TFilter, ctx?: any) => SqlFragment)
   ) => BuildView<
     TFilter & { [x in TKey]?: z.infer<typeof comparisonFilterType> },
     keyof TFilter | TKey,
@@ -145,11 +145,11 @@ export type BuildView<
    * */
   addDateFilter: <TKey extends Exclude<string, TFilterKey>>(
     name: TKey | TKey[],
-    mapper?: ((table: IdentifierSqlToken & {
+    mapper?: ((table: {
       [x in TAliases]: IdentifierSqlToken
     } & {
       [x: string]: IdentifierSqlToken
-    }, value?: z.infer<typeof dateFilterType>, allFilters?: any, ctx?: any) => SqlFragment)
+    }, value?: z.infer<typeof dateFilterType>, allFilters?: TFilter, ctx?: any) => SqlFragment)
   ) => BuildView<
     TFilter & { [x in TKey]?: z.infer<typeof dateFilterType> },
     keyof TFilter | TKey,
@@ -181,11 +181,11 @@ export type BuildView<
    */
   addBooleanFilter: <TKey extends Exclude<string, TFilterKey>>(
     name: TKey | TKey[],
-    mapper?: ((table: IdentifierSqlToken & {
+    mapper?: ((table: {
       [x in TAliases]: IdentifierSqlToken
     } & {
       [x: string]: IdentifierSqlToken
-    }, value?: boolean) => SqlFragment)
+    }, value?: boolean, allFilters?: TFilter, ctx?: any) => SqlFragment)
   ) => BuildView<TFilter & { [x in TKey]?: boolean }, keyof TFilter | TKey, TAliases>
   /**
    * Allows filtering by single or multiple string values
@@ -193,11 +193,11 @@ export type BuildView<
    * */
   addInArrayFilter: <TKey extends Exclude<string, TFilterKey>>(
     name: TKey | TKey[],
-    mapper?: ((table: IdentifierSqlToken & {
+    mapper?: ((table: {
       [x in TAliases]: IdentifierSqlToken
     } & {
       [x: string]: IdentifierSqlToken
-    }, value?: string | string[] | null) => SqlFragment)
+    }, value?: string | string[] | null, allFilters?: TFilter, ctx?: any) => SqlFragment)
   ) => BuildView<TFilter & { [x in TKey]?: string | string[] | null }, keyof TFilter | TKey, TAliases>
   /**
    * Use this to add a generic filter, that returns a SQL fragment

--- a/src/core/buildView.ts
+++ b/src/core/buildView.ts
@@ -1,147 +1,138 @@
-import { sql, ValueExpression, SqlFragment, IdentifierSqlToken, FragmentSqlToken } from 'slonik'
-import { z } from 'zod'
 import {
-  arrayDynamicFilter,
-  arrayFilter,
-  booleanFilter,
-  comparisonFilter,
-  comparisonFilterType,
-  dateFilter,
-  dateFilterType,
-  genericFilter,
-  jsonbContainsFilter,
-  stringFilter,
-  stringFilterType
-} from '../helpers/sqlUtils'
-import { notEmpty } from '../helpers/zod'
+    sql,
+    ValueExpression,
+    SqlFragment,
+    IdentifierSqlToken,
+    FragmentSqlToken,
+} from "slonik";
+import { z } from "zod";
+import {
+    arrayDynamicFilter,
+    arrayFilter,
+    booleanFilter,
+    comparisonFilter,
+    comparisonFilterType,
+    dateFilter,
+    dateFilterType,
+    genericFilter,
+    jsonbContainsFilter,
+    stringFilter,
+    stringFilterType,
+} from "../helpers/sqlUtils";
+import { notEmpty } from "../helpers/zod";
 
 export type Interpretors<
-  TFilter extends Record<string, any>,
-  TFilterKey extends keyof TFilter = keyof TFilter extends Record<infer K, any>
-    ? K extends string
-      ? K
-      : never
-    : never,
-  TContext = any
+    TFilter extends Record<string, any>,
+    TFilterKey extends keyof TFilter = keyof TFilter extends Record<
+        infer K,
+        any
+    >
+        ? K extends string
+            ? K
+            : never
+        : never,
+    TContext = any
 > = {
-  [x in TFilterKey]?: {
-    prefix?: string,
-    interpret: (
-      filter: TFilter[x],
-      allFilters: TFilter,
-      context: TContext
-    ) =>
-    | Promise<SqlFragment | null | undefined | false>
-    | SqlFragment
-    | null
-    | undefined
-    | false
-  }
-}
-
-/*
-Example usage with filters
-
-```ts
-buildView`FROM (SELECT users.*, COUNT(*) AS post_count FROM users LEFT JOIN posts ON posts.user_id = users.id GROUP BY users.id) users`
-  .addFilters(
-    usersView.getFilters({
-      mainTable: "users",// Possibility to override when there's more than one table visible
-      exclude: ["excludeThisFilter"],
-    }), {
-      preprocess: (filters, context) => {
-        return {
-          ...filters,
-          onlySpecificFilter: true
-        }
-      },
-    }
-  )
-  .withFilterPreprocess((filters, context) => {
-    return {
-      ...filters,
-      onlySpecificFilter: true
-    }
-  })
-  .addStringFilter("title")
-  .addStringFilter((table) => sql.fragment`COALESCE(${table}.first_name, ${table}.last_name)`)
-```
-
-Not sure which preprocessing makes more sense, probably the second one
-*/
-
+    [x in TFilterKey]?: {
+        prefix?: string;
+        interpret: (
+            filter: TFilter[x],
+            allFilters: TFilter,
+            context: TContext
+        ) =>
+            | Promise<SqlFragment | null | undefined | false>
+            | SqlFragment
+            | null
+            | undefined
+            | false;
+    };
+};
 
 export type BuildView<
-  TFilter extends Record<string, any> = Record<never, any>,
-  TFilterKey extends keyof TFilter = never,
-  TAliases extends string = "_main"
+    TFilter extends Record<string, any> = Record<never, any>,
+    TFilterKey extends keyof TFilter = never,
+    TAliases extends string = "_main"
 > = {
-  /**
-   * Allows adding custom filters to the view
-   * Multiple filters can be added at once
-   * This is mainly to be used in conjunction with getFilters
-   * WARNING: Do not use this otherwise, unless you know what you're doing.
-   * Prefer using the other filter methods, especially addGenericFilter if you need more flexibility
-   * @param filters - The filters to add
-   */
-  addFilters<
-    TNewFilter extends Record<string, any> = Record<never, any>,
-    TNewFilterKey extends keyof TNewFilter = keyof TNewFilter extends Record<
-      infer K,
-      any
-    >
-      ? K extends string
-        ? K
-        : never
-      : never
-  >(filters: {
-    [x in TNewFilterKey]?: (
-      filter: TNewFilter[x],
-      allFilters: TFilter & TNewFilter,
-      context: any
-    ) =>
-      | Promise<SqlFragment | null | undefined | false>
-      | SqlFragment
-      | null
-      | undefined
-      | false
-  }): BuildView<TNewFilter & TFilter, keyof TNewFilter | TFilterKey, TAliases>
-  /**
-   * Allows filtering by string operators, e.g. "contains", "starts with", "ends with", etc.
-   * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
-   * @param mapper - Optional if you want to use a different column name than the filter name
-   */
-  addStringFilter: <TKey extends Exclude<string, TFilterKey>>(
-    field: TKey | TKey[],
-    name?: ((table: {
-      [x in TAliases]: IdentifierSqlToken
-    } & {
-      [x: string]: IdentifierSqlToken
-    }, value?: z.infer<typeof stringFilterType>, allFilters?: TFilter, ctx?: any) => SqlFragment)
-  ) => BuildView<
-    TFilter & { [x in TKey]?: z.infer<typeof stringFilterType> },
-    keyof TFilter | TKey,
-    TAliases
-  >
-  /**
-   * Allows filtering by comparison operators, e.g. "greater than", "less than", "between", "in", etc.
-   * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
-   * @param mapper - Optional if you want to use a different column name than the filter name
-   * @returns
-   */
-  addComparisonFilter: <TKey extends Exclude<string, TFilterKey>>(
-    name: TKey | TKey[],
-    mapper?: ((table: {
-      [x in TAliases]: IdentifierSqlToken
-    } & {
-      [x: string]: IdentifierSqlToken
-    }, value?: z.infer<typeof comparisonFilterType>, allFilters?: TFilter, ctx?: any) => SqlFragment)
-  ) => BuildView<
-    TFilter & { [x in TKey]?: z.infer<typeof comparisonFilterType> },
-    keyof TFilter | TKey,
-    TAliases
-  >
-  /**
+    /**
+     * Allows adding custom filters to the view
+     * Multiple filters can be added at once
+     * This is mainly to be used in conjunction with getFilters
+     * WARNING: Do not use this otherwise, unless you know what you're doing.
+     * Prefer using the other filter methods, especially addGenericFilter if you need more flexibility
+     * @param filters - The filters to add
+     */
+    addFilters<
+        TNewFilter extends Record<string, any> = Record<never, any>,
+        TNewFilterKey extends keyof TNewFilter = keyof TNewFilter extends Record<
+            infer K,
+            any
+        >
+            ? K extends string
+                ? K
+                : never
+            : never
+    >(filters: {
+        [x in TNewFilterKey]?: (
+            filter: TNewFilter[x],
+            allFilters: TFilter & TNewFilter,
+            context: any
+        ) =>
+            | Promise<SqlFragment | null | undefined | false>
+            | SqlFragment
+            | null
+            | undefined
+            | false;
+    }): BuildView<
+        TNewFilter & TFilter,
+        keyof TNewFilter | TFilterKey,
+        TAliases
+    >;
+    /**
+     * Allows filtering by string operators, e.g. "contains", "starts with", "ends with", etc.
+     * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
+     * @param mapper - Optional if you want to use a different column name than the filter name
+     */
+    addStringFilter: <TKey extends Exclude<string, TFilterKey>>(
+        field: TKey | TKey[],
+        name?: (
+            table: {
+                [x in TAliases]: IdentifierSqlToken;
+            } & {
+                [x: string]: IdentifierSqlToken;
+            },
+            value?: z.infer<typeof stringFilterType>,
+            allFilters?: TFilter,
+            ctx?: any
+        ) => SqlFragment
+    ) => BuildView<
+        TFilter & { [x in TKey]?: z.infer<typeof stringFilterType> },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
+     * Allows filtering by comparison operators, e.g. "greater than", "less than", "between", "in", etc.
+     * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
+     * @param mapper - Optional if you want to use a different column name than the filter name
+     * @returns
+     */
+    addComparisonFilter: <TKey extends Exclude<string, TFilterKey>>(
+        name: TKey | TKey[],
+        mapper?: (
+            table: {
+                [x in TAliases]: IdentifierSqlToken;
+            } & {
+                [x: string]: IdentifierSqlToken;
+            },
+            value?: z.infer<typeof comparisonFilterType>,
+            allFilters?: TFilter,
+            ctx?: any
+        ) => SqlFragment
+    ) => BuildView<
+        TFilter & { [x in TKey]?: z.infer<typeof comparisonFilterType> },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
    * Allows filtering jsonb columns, using the @> operator to check if a JSONB column contains a certain value or structure.
    * ```
     view.addJsonContainsFilter('settings', () => sql.fragment`'user.user_settings'`)
@@ -159,388 +150,524 @@ export type BuildView<
       }
     ```
    * */
-  addJsonContainsFilter: <TKey extends Exclude<string, TFilterKey>>(
-    name: TKey | TKey[],
-    mapper?: ((table: {
-      [x in TAliases]: IdentifierSqlToken
-    } & {
-      [x: string]: IdentifierSqlToken
-    }, value?: any, allFilters?: TFilter, ctx?: any) => SqlFragment)
-  ) => BuildView<
-    TFilter & { [x in TKey]?: Parameters<typeof jsonbContainsFilter>[0] },
-    keyof TFilter | TKey,
-    TAliases
-  >
-  /**
-   * Allows filtering by date operators, e.g. "greater than", "less than" etc.
-   * */
-  addDateFilter: <TKey extends Exclude<string, TFilterKey>>(
-    name: TKey | TKey[],
-    mapper?: ((table: {
-      [x in TAliases]: IdentifierSqlToken
-    } & {
-      [x: string]: IdentifierSqlToken
-    }, value?: z.infer<typeof dateFilterType>, allFilters?: TFilter, ctx?: any) => SqlFragment)
-  ) => BuildView<
-    TFilter & { [x in TKey]?: z.infer<typeof dateFilterType> },
-    keyof TFilter | TKey,
-    TAliases
-  >
-  /**
-   * Allows preprocessing the filters before they are interpreted
-   * */
-  setFilterPreprocess: (preprocess: ((filters: TFilter, context: any) => Promise<TFilter> | TFilter)) => BuildView<TFilter, TFilterKey, TAliases>
-  /**
-   * Sets table aliases. By default there's a `_main` alias for the main table that's referenced in the FROM fragment.
-   * 
-   * These aliases can then be used in some of the filters, e.g.
-   * ```ts
-   * buildView`FROM users`
-   * .addStringFilter('name', (table) => sql.fragment`COALESCE(${table._main}.first_name, ${table._main}.last_name)`)
-   * ```
-   * 
-   * would be translated to `COALESCE(users.first_name, users.last_name)`
-   * 
-   * because `users` is the main table that's referred in the FROM clause.
-   * */
-  setTableAliases: <TNewAliases extends string>(table: Record<TNewAliases, string | IdentifierSqlToken>) => BuildView<TFilter, TFilterKey, TAliases | TNewAliases>
-  /**
-   * Allows filtering by boolean operators, e.g. "is true", "is false", "is null", etc.
-   * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
-   * @param mapper - Optional if you want to use a different column name than the filter name
-   * @returns
-   * */
-  addBooleanFilter: <TKey extends Exclude<string, TFilterKey>>(
-    name: TKey | TKey[],
-    mapper?: ((table: {
-      [x in TAliases]: IdentifierSqlToken
-    } & {
-      [x: string]: IdentifierSqlToken
-    }, value?: boolean, allFilters?: TFilter, ctx?: any) => SqlFragment)
-  ) => BuildView<TFilter & { [x in TKey]?: boolean }, keyof TFilter | TKey, TAliases>
-  /**
-   * Allows filtering by single or multiple string values
-   * And returns all rows where the value is in the array
-   * */
-  addInArrayFilter: <TKey extends Exclude<string, TFilterKey>, TType extends "text" | "numeric" | "integer" | "bigint"=never, TValue= [TType] extends [never] ? string : TType extends "numeric" | "integer" | "bigint" ? number : string>(
-    name: TKey | TKey[],
-    mapper?: ((table: {
-      [x in TAliases]: IdentifierSqlToken
-    } & {
-      [x: string]: IdentifierSqlToken
-    }, value?: TValue | TValue[] | null, allFilters?: TFilter, ctx?: any) => SqlFragment),
-    type?: TType
-  ) => BuildView<TFilter & { [x in TKey]?: TValue | TValue[] | null }, keyof TFilter | TKey, TAliases>
-  /**
-   * Use this to add a generic filter, that returns a SQL fragment
-   * This filter won't be applied if the value is null or undefined
-   * */
-  addGenericFilter: <TKey extends Exclude<string, TFilterKey>, TNewFilter>(
-    name: TKey,
-    interpret: (
-      filter: TNewFilter,
-      allFilters: TFilter & { TKey: TNewFilter },
-      context: any
-    ) =>
-      | Promise<SqlFragment | null | undefined | false>
-      | SqlFragment
-      | null
-      | undefined
-      | false
-  ) => BuildView<TFilter & { [x in TKey]?: TNewFilter }, keyof TFilter | TKey, TAliases>
-  /**
-   * Returns the SQL query
-   * @param args - The arguments to filter by
-   * @returns - The SQL query fragment
-   * */
-  getWhereConditions(args: {
-    where?: RecursiveFilterConditions<{
-      [x in TFilterKey]?: TFilter[x]
-    }>,
-    ctx?: any
-  }): Promise<SqlFragment[]>,
-  getWhereFragment(args: {
-    where?: RecursiveFilterConditions<{
-      [x in TFilterKey]?: TFilter[x]
-    }>,
-    ctx?: any
-  }): Promise<FragmentSqlToken>,
-  getFromFragment(): FragmentSqlToken,
-  /**
-   * Returns all filters that have been added to the view
-   * @param options - Options for configuring the filters
-   */
-  getFilters<
-    TInclude extends (Extract<TFilterKey, string> | `${string}*`)=never,
-    TExclude extends (Extract<TFilterKey, string> | `${string}*`)=never,
-    TRealInclude extends Extract<TFilterKey, string>=TInclude extends `${infer K}*` ? Extract<TFilterKey, `${K}${string}`> : Extract<TInclude, Extract<TFilterKey, string>>,
-    TRealExclude extends Extract<TFilterKey, string>=TExclude extends `${infer K}*` ? Extract<TFilterKey, `${K}${string}`> : Extract<TExclude, Extract<TFilterKey, string>>,
-    TPrefix extends string='',
-    TRealPrefix extends string=TPrefix extends `${string}.` ? TPrefix : `${TPrefix}.`
-  >(
-    options?: {
-      table?: TPrefix,
-      include?: readonly TInclude[],
-      exclude?: readonly TExclude[],
-    }
-  ): {
-    [x in TFilterKey extends TRealExclude ? never :
-      [TRealInclude] extends [never] ?
-      // ([TRealInclude] extends [never] ? TFilterKey : TFilterKey)
-      TFilterKey extends `${TRealPrefix}${string}`
-      ? TFilterKey
-      : `${TRealPrefix}${Extract<TFilterKey, string>}`
-    : TFilterKey extends `${TRealPrefix}${string}`
-    ? Extract<TFilterKey, TRealInclude>
-    : `${TRealPrefix}${Extract<TFilterKey, TRealInclude>}`]?: (
-      filter: TFilter[x extends `${TRealPrefix}${infer K}`
-        ? K extends TFilterKey
-          ? K
-          : x
-        : x],
-      allFilters: any,
-      context: any
-    ) =>
-      | Promise<SqlFragment | null | undefined | false>
-      | SqlFragment
-      | null
-      | undefined
-      | false
-  }
-} & SqlFragment
+    addJsonContainsFilter: <TKey extends Exclude<string, TFilterKey>>(
+        name: TKey | TKey[],
+        mapper?: (
+            table: {
+                [x in TAliases]: IdentifierSqlToken;
+            } & {
+                [x: string]: IdentifierSqlToken;
+            },
+            value?: any,
+            allFilters?: TFilter,
+            ctx?: any
+        ) => SqlFragment
+    ) => BuildView<
+        TFilter & { [x in TKey]?: Parameters<typeof jsonbContainsFilter>[0] },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
+     * Allows filtering by date operators, e.g. "greater than", "less than" etc.
+     * */
+    addDateFilter: <TKey extends Exclude<string, TFilterKey>>(
+        name: TKey | TKey[],
+        mapper?: (
+            table: {
+                [x in TAliases]: IdentifierSqlToken;
+            } & {
+                [x: string]: IdentifierSqlToken;
+            },
+            value?: z.infer<typeof dateFilterType>,
+            allFilters?: TFilter,
+            ctx?: any
+        ) => SqlFragment
+    ) => BuildView<
+        TFilter & { [x in TKey]?: z.infer<typeof dateFilterType> },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
+     * Allows preprocessing the filters before they are interpreted
+     * */
+    setFilterPreprocess: (
+        preprocess: (
+            filters: TFilter,
+            context: any
+        ) => Promise<TFilter> | TFilter
+    ) => BuildView<TFilter, TFilterKey, TAliases>;
+    /**
+     * Sets table aliases. By default there's a `_main` alias for the main table that's referenced in the FROM fragment.
+     *
+     * These aliases can then be used in some of the filters, e.g.
+     * ```ts
+     * buildView`FROM users`
+     * .addStringFilter('name', (table) => sql.fragment`COALESCE(${table._main}.first_name, ${table._main}.last_name)`)
+     * ```
+     *
+     * would be translated to `COALESCE(users.first_name, users.last_name)`
+     *
+     * because `users` is the main table that's referred in the FROM clause.
+     * */
+    setTableAliases: <TNewAliases extends string>(
+        table: Record<TNewAliases, string | IdentifierSqlToken>
+    ) => BuildView<TFilter, TFilterKey, TAliases | TNewAliases>;
+    /**
+     * Allows filtering by boolean operators, e.g. "is true", "is false", "is null", etc.
+     * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
+     * @param mapper - Optional if you want to use a different column name than the filter name
+     * @returns
+     * */
+    addBooleanFilter: <TKey extends Exclude<string, TFilterKey>>(
+        name: TKey | TKey[],
+        mapper?: (
+            table: {
+                [x in TAliases]: IdentifierSqlToken;
+            } & {
+                [x: string]: IdentifierSqlToken;
+            },
+            value?: boolean,
+            allFilters?: TFilter,
+            ctx?: any
+        ) => SqlFragment
+    ) => BuildView<
+        TFilter & { [x in TKey]?: boolean },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
+     * Allows filtering by single or multiple string values
+     * And returns all rows where the value is in the array
+     * */
+    addInArrayFilter: <
+        TKey extends Exclude<string, TFilterKey>,
+        TType extends "text" | "numeric" | "integer" | "bigint" = never,
+        TValue = [TType] extends [never]
+            ? string
+            : TType extends "numeric" | "integer" | "bigint"
+            ? number
+            : string
+    >(
+        name: TKey | TKey[],
+        mapper?: (
+            table: {
+                [x in TAliases]: IdentifierSqlToken;
+            } & {
+                [x: string]: IdentifierSqlToken;
+            },
+            value?: TValue | TValue[] | null,
+            allFilters?: TFilter,
+            ctx?: any
+        ) => SqlFragment,
+        type?: TType
+    ) => BuildView<
+        TFilter & { [x in TKey]?: TValue | TValue[] | null },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
+     * Use this to add a generic filter, that returns a SQL fragment
+     * This filter won't be applied if the value is null or undefined
+     * */
+    addGenericFilter: <TKey extends Exclude<string, TFilterKey>, TNewFilter>(
+        name: TKey,
+        interpret: (
+            filter: TNewFilter,
+            allFilters: TFilter & { TKey: TNewFilter },
+            context: any
+        ) =>
+            | Promise<SqlFragment | null | undefined | false>
+            | SqlFragment
+            | null
+            | undefined
+            | false
+    ) => BuildView<
+        TFilter & { [x in TKey]?: TNewFilter },
+        keyof TFilter | TKey,
+        TAliases
+    >;
+    /**
+     * Returns the SQL query
+     * @param args - The arguments to filter by
+     * @returns - The SQL query fragment
+     * */
+    getWhereConditions(args: {
+        where?: RecursiveFilterConditions<{
+            [x in TFilterKey]?: TFilter[x];
+        }>;
+        ctx?: any;
+        options?: FilterOptions;
+    }): Promise<SqlFragment[]>;
+    getWhereFragment(args: {
+        where?: RecursiveFilterConditions<{
+            [x in TFilterKey]?: TFilter[x];
+        }>;
+        ctx?: any;
+        options?: FilterOptions;
+    }): Promise<FragmentSqlToken>;
+    getFromFragment(): FragmentSqlToken;
+    /**
+     * Returns all filters that have been added to the view
+     * @param options - Options for configuring the filters
+     */
+    getFilters<
+        TInclude extends Extract<TFilterKey, string> | `${string}*` = never,
+        TExclude extends Extract<TFilterKey, string> | `${string}*` = never,
+        TRealInclude extends Extract<
+            TFilterKey,
+            string
+        > = TInclude extends `${infer K}*`
+            ? Extract<TFilterKey, `${K}${string}`>
+            : Extract<TInclude, Extract<TFilterKey, string>>,
+        TRealExclude extends Extract<
+            TFilterKey,
+            string
+        > = TExclude extends `${infer K}*`
+            ? Extract<TFilterKey, `${K}${string}`>
+            : Extract<TExclude, Extract<TFilterKey, string>>,
+        TPrefix extends string = "",
+        TRealPrefix extends string = TPrefix extends `${string}.`
+            ? TPrefix
+            : `${TPrefix}.`
+    >(options?: {
+        table?: TPrefix;
+        include?: readonly TInclude[];
+        exclude?: readonly TExclude[];
+    }): {
+        [x in TFilterKey extends TRealExclude
+            ? never
+            : [TRealInclude] extends [never]
+            ? // ([TRealInclude] extends [never] ? TFilterKey : TFilterKey)
+              TFilterKey extends `${TRealPrefix}${string}`
+                ? TFilterKey
+                : `${TRealPrefix}${Extract<TFilterKey, string>}`
+            : TFilterKey extends `${TRealPrefix}${string}`
+            ? Extract<TFilterKey, TRealInclude>
+            : `${TRealPrefix}${Extract<TFilterKey, TRealInclude>}`]?: (
+            filter: TFilter[x extends `${TRealPrefix}${infer K}`
+                ? K extends TFilterKey
+                    ? K
+                    : x
+                : x],
+            allFilters: any,
+            context: any
+        ) =>
+            | Promise<SqlFragment | null | undefined | false>
+            | SqlFragment
+            | null
+            | undefined
+            | false;
+    };
+} & SqlFragment;
 
+type FilterOptions = {
+    orEnabled: boolean;
+};
 
 export const buildView = (
-  parts: readonly string[],
-  ...values: readonly ValueExpression[]
+    parts: readonly string[],
+    ...values: readonly ValueExpression[]
 ) => {
-  const fromFragment = sql.fragment(parts, ...values)
-  if (!fromFragment.sql.match(/^\s*FROM/i)) {
-    throw new Error('First part of view must be FROM')
-  }
-  const preprocessors = [] as ((filters: any, context: any) => Promise<any> | any)[];
-  const config = {
-    table: fromFragment.sql.match(/^FROM\s*(\w+)/i)?.[1],
-    aliases: new Map<string, string>(),
-  };
-  const identifierProxy = new Proxy({} as any, {
-    get(target, property) {
-      if (property === '_main') return sql.identifier([config.aliases.get(property) || config.table || '']);
-      return sql.identifier([config.aliases.get(property as string) || property as string]);
+    const fromFragment = sql.fragment(parts, ...values);
+    if (!fromFragment.sql.match(/^\s*FROM/i)) {
+        throw new Error("First part of view must be FROM");
     }
-  });
-  if (!config.table) {
-    config.table = fromFragment.sql.match(/(AS|\))\s+(\w+)\s*$/i)?.[2]
-  }
-  if (!config.table) {
-    console.warn(`Could not determine table name for ${fromFragment.sql}. Please use setAliases({ _main: 'tableName' }) to set the table name manually.`);
-  }
-  const interpreters = {} as Interpretors<Record<string, any>>
-
-  const getWhereConditions = async (
-    filters: RecursiveFilterConditions<any>,
-    context?: any
-  ) => {
-    const postprocessedFilters = await preprocessors.slice(-1).reduce(async (acc, preprocessor) => {
-      const filters = await acc;
-      return preprocessor(filters, context);
-    }, filters);
-    const conditions = await interpretFilter(postprocessedFilters || filters, interpreters as any, context)
-    return conditions;
-  }
-  const getWhereFragment = async (
-    filters: RecursiveFilterConditions<any>,
-    context?: any
-  ) => {
-    const conditions = await getWhereConditions(filters, context)
-    return conditions.length
-      ? sql.fragment`WHERE (${sql.join(conditions, sql.fragment`\n) AND(\n`)})`
-      : sql.fragment``
-  }
-
-  const getFromFragment = () => {
-    // return sql.fragment`${fromFragment} ${await getWhereFragment(args.where, args.ctx)}`
-    return fromFragment;
-  }
-
-  const addFilter = (interpreter: (value: any, field: FragmentSqlToken) => any, fields: string | string[], mapper?: ((table: IdentifierSqlToken | Record<string, IdentifierSqlToken>, value?: any, allFilters?: any, context?: any) => SqlFragment)) => {
-    if (mapper && Array.isArray(fields) && fields.length > 1) {
-      throw new Error('If you specify a mapper function you cannot have multiple filter keys');
+    const preprocessors = [] as ((
+        filters: any,
+        context: any
+    ) => Promise<any> | any)[];
+    const config = {
+        table: fromFragment.sql.match(/^FROM\s*(\w+)/i)?.[1],
+        aliases: new Map<string, string>(),
+    };
+    const identifierProxy = new Proxy({} as any, {
+        get(target, property) {
+            if (property === "_main")
+                return sql.identifier([
+                    config.aliases.get(property) || config.table || "",
+                ]);
+            return sql.identifier([
+                config.aliases.get(property as string) || (property as string),
+            ]);
+        },
+    });
+    if (!config.table) {
+        config.table = fromFragment.sql.match(/(AS|\))\s+(\w+)\s*$/i)?.[2];
     }
-    return self.addFilters((Array.isArray(fields) ? fields : [fields]).reduce((acc, key) => {
-      return {
-        ...acc,
-        [key]: (value: any, allFilters: any, ctx: any, key: string) => {
-          const keys = key.split('.');
-          if (keys.length > 2) {
-            // Ignore middle keys (earlier prefixes), only first and last matter
-            keys.splice(1, keys.length - 2);
-          }
-          const identifier = mapper ?
-            // Try to get the table name from the 2nd to last prefix if it exists, if not then use main table
-            mapper(identifierProxy, value, allFilters, ctx) :
-              config.table && keys.length <= 1 ?
-                (sql.identifier([config.table, ...keys.slice(-1)]) as any) :
-                (sql.identifier([...keys.slice(-2)]) as any)
-          return interpreter(
-            value,
-            identifier,
-          )
+    if (!config.table) {
+        console.warn(
+            `Could not determine table name for ${fromFragment.sql}. Please use setAliases({ _main: 'tableName' }) to set the table name manually.`
+        );
+    }
+    const interpreters = {} as Interpretors<Record<string, any>>;
+
+    const getWhereConditions = async (
+        filters: RecursiveFilterConditions<any>,
+        context?: any,
+        options?: FilterOptions
+    ) => {
+        const postprocessedFilters = await preprocessors.slice(-1).reduce(
+            async (acc, preprocessor) => {
+                const filters = await acc;
+                return preprocessor(filters, context);
+            }, filters);
+        const conditions = await interpretFilter(
+            postprocessedFilters || filters,
+            interpreters as any,
+            context,
+            options,
+        );
+        return conditions;
+    };
+    const getWhereFragment = async (
+        filters: RecursiveFilterConditions<any>,
+        context?: any,
+        options?: FilterOptions
+    ) => {
+        const conditions = await getWhereConditions(filters, context, options);
+        return conditions.length
+            ? sql.fragment`WHERE (${sql.join(
+                  conditions,
+                  sql.fragment`\n) AND(\n`
+              )})`
+            : sql.fragment``;
+    };
+
+    const getFromFragment = () => {
+        // return sql.fragment`${fromFragment} ${await getWhereFragment(args.where, args.ctx)}`
+        return fromFragment;
+    };
+
+    const addFilter = (
+        interpreter: (value: any, field: FragmentSqlToken) => any,
+        fields: string | string[],
+        mapper?: (
+            table: IdentifierSqlToken | Record<string, IdentifierSqlToken>,
+            value?: any,
+            allFilters?: any,
+            context?: any
+        ) => SqlFragment
+    ) => {
+        if (mapper && Array.isArray(fields) && fields.length > 1) {
+            throw new Error(
+                "If you specify a mapper function you cannot have multiple filter keys"
+            );
         }
-      }
-    }, {}));
-  }
-  const self = {
-    ...fromFragment,
-    getFromFragment,
-    addFilters(filters: any) {
-      Object.assign(interpreters, filters)
-      return self
-    },
-    setTableAliases(newAliases: Record<string, string | IdentifierSqlToken>) {
-      for (const [key, value] of Object.entries(newAliases)) {
-        config.aliases.set(key, value as string);
-      }
-      return self;
-    },
-    setFilterPreprocess(preprocess: ((filters: any, context: any) => Promise<any> | any)) {
-      preprocessors.push(preprocess);
-      return self;
-    },
-    getFilters(options?: any) {
-      let prefix = options?.table || '';
-      if (prefix && !prefix.endsWith('.')) {
-        prefix += '.';
-      }
-      const exclude = (options?.exclude || []) as string[];
-      const include = (options?.include || []) as string[];
-      const filters = {} as any
-      for (const key of Object.keys(interpreters)) {
-        // exclude may have * wildcards that exclude all filters that start with the prefix
-        if (exclude.some(ex => ex.endsWith('*') ? key.startsWith(ex.replace('*', '')) : ex === key)) {
-          continue;
-        }
-        const isIncluded = !include.length || include.some(ex => ex.endsWith('*') ? key.startsWith(ex.replace('*', '')) : ex === key);
-        if (isIncluded) {
-          filters[prefix + key.replace(prefix, '')] = {
-            interpret: (interpreters as any)[key]?.interpret || (interpreters as any)[key],
-            prefix: key.startsWith(prefix) ? '' : prefix,
-          }
-        }
-      }
-      return filters
-    },
-    addStringFilter: (keys: string | string[], name?: any) => {
-      return addFilter(stringFilter, keys, name);
-    },
-    addComparisonFilter: (keys: string | string[], name?: any) => {
-      return addFilter(comparisonFilter, keys, name);
-    },
-    addBooleanFilter: (keys: string | string[], name?: any) => {
-      return addFilter(booleanFilter, keys, name);
-    },
-    addJsonContainsFilter: (keys: string | string[], name?: any) => {
-      return addFilter(jsonbContainsFilter, keys, name);
-    },
-    addDateFilter: (keys: string | string[], name?: any) => {
-      return addFilter(dateFilter, keys, name);
-    },
-    addInArrayFilter: (keys: string | string[], name?: any, type?: string) => {
-      const arrFilter = type ? arrayDynamicFilter(type) : arrayFilter;
-      return addFilter(arrFilter, keys, name);
-    },
-    addGenericFilter: (name: string, interpret?: any) => {
-      return addFilter(genericFilter, name, (table, value, ...args) => {
-        return interpret(value, ...args);
-      });
-    },
-    getWhereConditions: async (args: any) => {
-      return getWhereConditions(
-        args.where,
-        args.ctx
-      )
-    },
-    getWhereFragment: async (args: any) => {
-      return getWhereFragment(
-        args.where,
-        args.ctx
-      )
-    },
-  }
-  return self as BuildView
-}
+        return self.addFilters(
+            (Array.isArray(fields) ? fields : [fields]).reduce((acc, key) => {
+                return {
+                    ...acc,
+                    [key]: (
+                        value: any,
+                        allFilters: any,
+                        ctx: any,
+                        key: string
+                    ) => {
+                        const keys = key.split(".");
+                        if (keys.length > 2) {
+                            // Ignore middle keys (earlier prefixes), only first and last matter
+                            keys.splice(1, keys.length - 2);
+                        }
+                        const identifier = mapper
+                            ? // Try to get the table name from the 2nd to last prefix if it exists, if not then use main table
+                              mapper(identifierProxy, value, allFilters, ctx)
+                            : config.table && keys.length <= 1
+                            ? (sql.identifier([
+                                  config.table,
+                                  ...keys.slice(-1),
+                              ]) as any)
+                            : (sql.identifier([...keys.slice(-2)]) as any);
+                        return interpreter(value, identifier);
+                    },
+                };
+            }, {})
+        );
+    };
+    const self = {
+        ...fromFragment,
+        getFromFragment,
+        addFilters(filters: any) {
+            Object.assign(interpreters, filters);
+            return self;
+        },
+        setTableAliases(
+            newAliases: Record<string, string | IdentifierSqlToken>
+        ) {
+            for (const [key, value] of Object.entries(newAliases)) {
+                config.aliases.set(key, value as string);
+            }
+            return self;
+        },
+        setFilterPreprocess(
+            preprocess: (filters: any, context: any) => Promise<any> | any
+        ) {
+            preprocessors.push(preprocess);
+            return self;
+        },
+        getFilters(options?: any) {
+            let prefix = options?.table || "";
+            if (prefix && !prefix.endsWith(".")) {
+                prefix += ".";
+            }
+            const exclude = (options?.exclude || []) as string[];
+            const include = (options?.include || []) as string[];
+            const filters = {} as any;
+            for (const key of Object.keys(interpreters)) {
+                // exclude may have * wildcards that exclude all filters that start with the prefix
+                if (
+                    exclude.some((ex) =>
+                        ex.endsWith("*")
+                            ? key.startsWith(ex.replace("*", ""))
+                            : ex === key
+                    )
+                ) {
+                    continue;
+                }
+                const isIncluded =
+                    !include.length ||
+                    include.some((ex) =>
+                        ex.endsWith("*")
+                            ? key.startsWith(ex.replace("*", ""))
+                            : ex === key
+                    );
+                if (isIncluded) {
+                    filters[prefix + key.replace(prefix, "")] = {
+                        interpret:
+                            (interpreters as any)[key]?.interpret ||
+                            (interpreters as any)[key],
+                        prefix: key.startsWith(prefix) ? "" : prefix,
+                    };
+                }
+            }
+            return filters;
+        },
+        addStringFilter: (keys: string | string[], name?: any) => {
+            return addFilter(stringFilter, keys, name);
+        },
+        addComparisonFilter: (keys: string | string[], name?: any) => {
+            return addFilter(comparisonFilter, keys, name);
+        },
+        addBooleanFilter: (keys: string | string[], name?: any) => {
+            return addFilter(booleanFilter, keys, name);
+        },
+        addJsonContainsFilter: (keys: string | string[], name?: any) => {
+            return addFilter(jsonbContainsFilter, keys, name);
+        },
+        addDateFilter: (keys: string | string[], name?: any) => {
+            return addFilter(dateFilter, keys, name);
+        },
+        addInArrayFilter: (
+            keys: string | string[],
+            name?: any,
+            type?: string
+        ) => {
+            const arrFilter = type ? arrayDynamicFilter(type) : arrayFilter;
+            return addFilter(arrFilter, keys, name);
+        },
+        addGenericFilter: (name: string, interpret?: any) => {
+            return addFilter(genericFilter, name, (table, value, ...args) => {
+                return interpret(value, ...args);
+            });
+        },
+        getWhereConditions: async (args: any) => {
+            return getWhereConditions(args.where, args.ctx, args.options);
+        },
+        getWhereFragment: async (args: any) => {
+            return getWhereFragment(args.where, args.ctx, args.options);
+        },
+    };
+    return self as BuildView;
+};
 
 export type RecursiveFilterConditions<
-  TFilter,
-  TDisabled extends 'AND' | 'OR' | 'NOT' = never
+    TFilter,
+    TDisabled extends "AND" | "OR" | "NOT" = never
 > = TFilter &
-  Omit<
-    {
-      AND?: RecursiveFilterConditions<TFilter>[]
-      OR?: RecursiveFilterConditions<TFilter>[]
-      NOT?: RecursiveFilterConditions<TFilter>
-    },
-    TDisabled
-  >
+    Omit<
+        {
+            AND?: RecursiveFilterConditions<TFilter>[];
+            OR?: RecursiveFilterConditions<TFilter>[];
+            NOT?: RecursiveFilterConditions<TFilter>;
+        },
+        TDisabled
+    >;
 
 const interpretFilter = async <TFilter extends Record<string, any>>(
-  filter: RecursiveFilterConditions<TFilter>,
-  interpreters: Interpretors<TFilter>,
-  context?: any
+    filter: RecursiveFilterConditions<TFilter>,
+    interpreters: Interpretors<TFilter>,
+    context?: any,
+    options?: FilterOptions
 ) => {
-  const conditions = [] as SqlFragment[]
-  const addCondition = (item: SqlFragment | null) =>
-    item && conditions.push(item)
-  for (const key of Object.keys(filter)) {
-    const interpreter = interpreters[key as never] as any
-    const condition = await (interpreter?.interpret || interpreter)?.(
-      filter[key as never],
-      filter as TFilter,
-      context,
-      key,
-    )
-    if (condition) {
-      addCondition(condition)
+    const conditions = [] as SqlFragment[];
+    const addCondition = (item: SqlFragment | null) =>
+        item && conditions.push(item);
+    for (const key of Object.keys(filter)) {
+        const interpreter = interpreters[key as never] as any;
+        const condition = await (interpreter?.interpret || interpreter)?.(
+            filter[key as never],
+            filter as TFilter,
+            context,
+            key
+        );
+        if (condition) {
+            addCondition(condition);
+        }
     }
-  }
-  if (filter.OR?.length) {
-    const orConditions = await Promise.all(
-      filter.OR.map(async or => {
-        const orFilter = await interpretFilter(or, interpreters, context)
-        return orFilter?.length
-          ? sql.fragment`(${sql.join(orFilter, sql.fragment`) AND (`)})`
-          : null
-      })
-    ).then(filters => filters.filter(notEmpty))
-    if (orConditions?.length) {
-      addCondition(
-        sql.fragment`(${sql.join(orConditions, sql.fragment`) OR (`)})`
-      )
+    if (filter.OR?.length) {
+        if (!options?.orEnabled) {
+            throw new Error(
+                "OR filters are not enabled. Please enable by passing { orFilterEnabled: true } in the options"
+            );
+        }
+        const orConditions = await Promise.all(
+            filter.OR.map(async (or) => {
+                const orFilter = await interpretFilter(or, interpreters, context, options);
+                return orFilter?.length
+                    ? sql.fragment`(${sql.join(
+                          orFilter,
+                          sql.fragment`) AND (`
+                      )})`
+                    : null;
+            })
+        ).then((filters) => filters.filter(notEmpty));
+        if (orConditions?.length) {
+            addCondition(
+                sql.fragment`(${sql.join(orConditions, sql.fragment`) OR (`)})`
+            );
+        }
     }
-  }
-  if (filter.AND?.length) {
-    const andConditions = await Promise.all(
-      filter.AND.map(async and => {
-        const andFilter = await interpretFilter(and, interpreters, context)
-        return andFilter?.length
-          ? sql.fragment`(${sql.join(andFilter, sql.fragment`) AND (`)})`
-          : null
-      })
-    ).then(filters => filters.filter(notEmpty))
-    if (andConditions?.length) {
-      addCondition(
-        sql.fragment`(${sql.join(andConditions, sql.fragment`) AND (`)})`
-      )
+    if (filter.AND?.length) {
+        const andConditions = await Promise.all(
+            filter.AND.map(async (and) => {
+                const andFilter = await interpretFilter(and, interpreters, context, options);
+                return andFilter?.length
+                    ? sql.fragment`(${sql.join(
+                          andFilter,
+                          sql.fragment`) AND (`
+                      )})`
+                    : null;
+            })
+        ).then((filters) => filters.filter(notEmpty));
+        if (andConditions?.length) {
+            addCondition(
+                sql.fragment`(${sql.join(
+                    andConditions,
+                    sql.fragment`) AND (`
+                )})`
+            );
+        }
     }
-  }
-  if (filter.NOT) {
-    const notFilter = await interpretFilter(filter.NOT, interpreters, context)
-    if (notFilter.length) {
-      addCondition(
-        sql.fragment`NOT (${sql.join(notFilter, sql.fragment`) AND (`)})`
-      )
+    if (filter.NOT) {
+        const notFilter = await interpretFilter(filter.NOT, interpreters, context, options);
+        if (notFilter.length) {
+            addCondition(
+                sql.fragment`NOT (${sql.join(
+                    notFilter,
+                    sql.fragment`) AND (`
+                )})`
+            );
+        }
     }
-  }
 
-  return conditions
-}
+    return conditions;
+};

--- a/src/core/buildView.ts
+++ b/src/core/buildView.ts
@@ -94,7 +94,7 @@ export type BuildView<
      */
     addStringFilter: <TKey extends Exclude<string, TFilterKey>>(
         field: TKey | TKey[],
-        name?: (
+        name?: SqlFragment | ((
             table: {
                 [x in TAliases]: IdentifierSqlToken;
             } & {
@@ -103,7 +103,7 @@ export type BuildView<
             value?: z.infer<typeof stringFilterType>,
             allFilters?: TFilter,
             ctx?: any
-        ) => SqlFragment
+        ) => SqlFragment)
     ) => BuildView<
         TFilter & { [x in TKey]?: z.infer<typeof stringFilterType> },
         keyof TFilter | TKey,
@@ -117,7 +117,7 @@ export type BuildView<
      */
     addComparisonFilter: <TKey extends Exclude<string, TFilterKey>>(
         name: TKey | TKey[],
-        mapper?: (
+        mapper?: SqlFragment | ((
             table: {
                 [x in TAliases]: IdentifierSqlToken;
             } & {
@@ -126,7 +126,7 @@ export type BuildView<
             value?: z.infer<typeof comparisonFilterType>,
             allFilters?: TFilter,
             ctx?: any
-        ) => SqlFragment
+        ) => SqlFragment)
     ) => BuildView<
         TFilter & { [x in TKey]?: z.infer<typeof comparisonFilterType> },
         keyof TFilter | TKey,
@@ -152,7 +152,7 @@ export type BuildView<
    * */
     addJsonContainsFilter: <TKey extends Exclude<string, TFilterKey>>(
         name: TKey | TKey[],
-        mapper?: (
+        mapper?: SqlFragment | ((
             table: {
                 [x in TAliases]: IdentifierSqlToken;
             } & {
@@ -161,7 +161,7 @@ export type BuildView<
             value?: any,
             allFilters?: TFilter,
             ctx?: any
-        ) => SqlFragment
+        ) => SqlFragment)
     ) => BuildView<
         TFilter & { [x in TKey]?: Parameters<typeof jsonbContainsFilter>[0] },
         keyof TFilter | TKey,
@@ -172,7 +172,7 @@ export type BuildView<
      * */
     addDateFilter: <TKey extends Exclude<string, TFilterKey>>(
         name: TKey | TKey[],
-        mapper?: (
+        mapper?: SqlFragment | ((
             table: {
                 [x in TAliases]: IdentifierSqlToken;
             } & {
@@ -181,7 +181,7 @@ export type BuildView<
             value?: z.infer<typeof dateFilterType>,
             allFilters?: TFilter,
             ctx?: any
-        ) => SqlFragment
+        ) => SqlFragment)
     ) => BuildView<
         TFilter & { [x in TKey]?: z.infer<typeof dateFilterType> },
         keyof TFilter | TKey,
@@ -220,7 +220,7 @@ export type BuildView<
      * */
     addBooleanFilter: <TKey extends Exclude<string, TFilterKey>>(
         name: TKey | TKey[],
-        mapper?: (
+        mapper?: SqlFragment | ((
             table: {
                 [x in TAliases]: IdentifierSqlToken;
             } & {
@@ -229,7 +229,7 @@ export type BuildView<
             value?: boolean,
             allFilters?: TFilter,
             ctx?: any
-        ) => SqlFragment
+        ) => SqlFragment)
     ) => BuildView<
         TFilter & { [x in TKey]?: boolean },
         keyof TFilter | TKey,
@@ -249,7 +249,7 @@ export type BuildView<
             : string
     >(
         name: TKey | TKey[],
-        mapper?: (
+        mapper?: SqlFragment | ((
             table: {
                 [x in TAliases]: IdentifierSqlToken;
             } & {
@@ -258,7 +258,7 @@ export type BuildView<
             value?: TValue | TValue[] | null,
             allFilters?: TFilter,
             ctx?: any
-        ) => SqlFragment,
+        ) => SqlFragment),
         type?: TType
     ) => BuildView<
         TFilter & { [x in TKey]?: TValue | TValue[] | null },
@@ -436,12 +436,12 @@ export const buildView = (
     const addFilter = (
         interpreter: (value: any, field: FragmentSqlToken) => any,
         fields: string | string[],
-        mapper?: (
+        mapper?: SqlFragment | ((
             table: IdentifierSqlToken | Record<string, IdentifierSqlToken>,
             value?: any,
             allFilters?: any,
             context?: any
-        ) => SqlFragment
+        ) => SqlFragment)
     ) => {
         if (mapper && Array.isArray(fields) && fields.length > 1) {
             throw new Error(
@@ -465,7 +465,7 @@ export const buildView = (
                         }
                         const identifier = mapper
                             ? // Try to get the table name from the 2nd to last prefix if it exists, if not then use main table
-                              mapper(identifierProxy, value, allFilters, ctx)
+                              typeof mapper === 'function' ? mapper(identifierProxy, value, allFilters, ctx) : mapper
                             : config.table && keys.length <= 1
                             ? (sql.identifier([
                                   config.table,

--- a/src/core/buildView.ts
+++ b/src/core/buildView.ts
@@ -1,0 +1,448 @@
+import { sql, ValueExpression, SqlFragment, IdentifierSqlToken, FragmentSqlToken } from 'slonik'
+import { z } from 'zod'
+import {
+  arrayFilter,
+  booleanFilter,
+  comparisonFilter,
+  comparisonFilterType,
+  genericFilter,
+  stringFilter,
+  stringFilterType
+} from '../helpers/sqlUtils'
+import { notEmpty } from '../helpers/zod'
+
+export type Interpretors<
+  TFilter extends Record<string, any>,
+  TFilterKey extends keyof TFilter = keyof TFilter extends Record<infer K, any>
+    ? K extends string
+      ? K
+      : never
+    : never,
+  TContext = any
+> = {
+  [x in TFilterKey]?: {
+    prefix?: string,
+    interpret: (
+      filter: TFilter[x],
+      allFilters: TFilter,
+      context: TContext
+    ) =>
+    | Promise<SqlFragment | null | undefined | false>
+    | SqlFragment
+    | null
+    | undefined
+    | false
+  }
+}
+
+/*
+Example usage with filters
+
+```ts
+buildView`FROM (SELECT users.*, COUNT(*) AS post_count FROM users LEFT JOIN posts ON posts.user_id = users.id GROUP BY users.id) users`
+  .setMainTable("users")
+  .addFilters(
+    usersView.getFilters({
+      mainTable: "users",// Possibility to override when there's more than one table visible
+      exclude: ["excludeThisFilter"],
+    }), {
+      preprocess: (filters, context) => {
+        return {
+          ...filters,
+          onlySpecificFilter: true
+        }
+      },
+    }
+  )
+  .withFilterPreprocess((filters, context) => {
+    return {
+      ...filters,
+      onlySpecificFilter: true
+    }
+  })
+  .addStringFilter("title")
+  .addStringFilter((table) => sql.fragment`COALESCE(${table}.first_name, ${table}.last_name)`)
+```
+
+Not sure which preprocessing makes more sense, probably the second one
+*/
+
+
+export type BuildView<
+  TFilter extends Record<string, any> = Record<never, any>,
+  TFilterKey extends keyof TFilter = never
+> = {
+  /**
+   * Allows adding custom filters to the view
+   * Multiple filters can be added at once
+   * WARNING: Do not use this unless you know what you're doing.
+   * Prefer using the other filter methods, especially addGenericFilter if you need more flexibility
+   * @param filters - The filters to add
+   */
+  addFilters<
+    TNewFilter extends Record<string, any> = Record<never, any>,
+    TNewFilterKey extends keyof TNewFilter = keyof TNewFilter extends Record<
+      infer K,
+      any
+    >
+      ? K extends string
+        ? K
+        : never
+      : never
+  >(filters: {
+    [x in TNewFilterKey]?: (
+      filter: TNewFilter[x],
+      allFilters: TFilter & TNewFilter,
+      context: any
+    ) =>
+      | Promise<SqlFragment | null | undefined | false>
+      | SqlFragment
+      | null
+      | undefined
+      | false
+  }): BuildView<TNewFilter & TFilter, keyof TNewFilter | TFilterKey>
+  /**
+   * Allows filtering by string operators, e.g. "contains", "starts with", "ends with", etc.
+   * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
+   * @param mapper - Optional if you want to use a different column name than the filter name
+   */
+  addStringFilter: <TKey extends Exclude<string, TFilterKey>>(
+    field: TKey | TKey[],
+    name?: ((table: IdentifierSqlToken, value?: z.infer<typeof stringFilterType>) => SqlFragment)
+  ) => BuildView<
+    TFilter & { [x in TKey]?: z.infer<typeof stringFilterType> },
+    keyof TFilter | TKey
+  >
+  /**
+   * Allows filtering by comparison operators, e.g. "greater than", "less than", "between", "in", etc.
+   * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
+   * @param mapper - Optional if you want to use a different column name than the filter name
+   * @returns
+   */
+  addComparisonFilter: <TKey extends Exclude<string, TFilterKey>>(
+    // Not adding allFilters + context in the interface until the API becomes more stable
+    name: TKey | TKey[],
+    mapper?: ((table: IdentifierSqlToken, value?: z.infer<typeof comparisonFilterType>) => SqlFragment)
+  ) => BuildView<
+    TFilter & { [x in TKey]?: z.infer<typeof comparisonFilterType> },
+    keyof TFilter | TKey
+  >
+  /**
+   * Allows preprocessing the filters before they are interpreted
+  */
+  setFilterPreprocess: (preprocess: ((filters: TFilter, context: any) => Promise<TFilter> | TFilter)) => BuildView<TFilter, TFilterKey>
+  /**
+   * Sets the main table of the view
+   * By default this is the first table in the FROM clause
+   **/
+  setMainTable: (table: string) => BuildView<TFilter, TFilterKey>
+  /**
+   * Allows filtering by boolean operators, e.g. "is true", "is false", "is null", etc.
+   * @param field - The name of the filter - Can be a nested field, e.g. "user.name"
+   * @param mapper - Optional if you want to use a different column name than the filter name
+   * @returns
+   */
+  addBooleanFilter: <TKey extends Exclude<string, TFilterKey>>(
+    name: TKey | TKey[],
+    mapper?: ((table: IdentifierSqlToken, value?: boolean) => SqlFragment)
+  ) => BuildView<TFilter & { [x in TKey]?: boolean }, keyof TFilter | TKey>
+  /**
+   * Allows filtering by single or multiple string values
+   * And returns all rows where the value is in the array
+   * */
+  addInArrayFilter: <TKey extends Exclude<string, TFilterKey>>(
+    name: TKey | TKey[],
+    mapper?: ((table: IdentifierSqlToken, value?: string | string[] | null) => SqlFragment)
+  ) => BuildView<TFilter & { [x in TKey]?: string | string[] | null }, keyof TFilter | TKey>
+  /**
+   * Use this to add a generic filter, that returns a SQL fragment
+   * This filter won't be applied if the value is null or undefined
+   * */
+  addGenericFilter: <TKey extends Exclude<string, TFilterKey>, TNewFilter>(
+    name: TKey,
+    interpret: (
+      filter: TNewFilter,
+      allFilters: TFilter & { TKey: TNewFilter },
+      context: any
+    ) =>
+      | Promise<SqlFragment | null | undefined | false>
+      | SqlFragment
+      | null
+      | undefined
+      | false
+  ) => BuildView<TFilter & { [x in TKey]?: TNewFilter }, keyof TFilter | TKey>
+  /**
+   * Returns the SQL query
+   * @param args - The arguments to filter by
+   * @returns - The SQL query fragment
+   * */
+  getWhereConditions(args: {
+    where?: RecursiveFilterConditions<{
+      [x in TFilterKey]?: TFilter[x]
+    }>,
+    ctx?: any
+  }): Promise<SqlFragment[]>,
+  getWhereFragment(args: {
+    where?: RecursiveFilterConditions<{
+      [x in TFilterKey]?: TFilter[x]
+    }>,
+    ctx?: any
+  }): Promise<FragmentSqlToken>,
+  getFromFragment(): FragmentSqlToken,
+  getFilters<
+    TInclude extends (Extract<TFilterKey, string> | `${string}*`)=never,
+    TExclude extends (Extract<TFilterKey, string> | `${string}*`)=never,
+    TRealInclude extends Extract<TFilterKey, string>=TInclude extends `${infer K}*` ? Extract<TFilterKey, `${K}${string}`> : Extract<TInclude, Extract<TFilterKey, string>>,
+    TRealExclude extends Extract<TFilterKey, string>=TExclude extends `${infer K}*` ? Extract<TFilterKey, `${K}${string}`> : Extract<TExclude, Extract<TFilterKey, string>>,
+    TPrefix extends string='',
+    TRealPrefix extends string=TPrefix extends `${string}.` ? TPrefix : `${TPrefix}.`
+  >(
+    options?: {
+      table?: TPrefix,
+      include?: readonly TInclude[],
+      exclude?: readonly TExclude[],
+    }
+  ): {
+    [x in TFilterKey extends TRealExclude ? never :
+      [TRealInclude] extends [never] ?
+      // ([TRealInclude] extends [never] ? TFilterKey : TFilterKey)
+      TFilterKey extends `${TRealPrefix}${string}`
+      ? TFilterKey
+      : `${TRealPrefix}${Extract<TFilterKey, string>}`
+    : TFilterKey extends `${TRealPrefix}${string}`
+    ? Extract<TFilterKey, TRealInclude>
+    : `${TRealPrefix}${Extract<TFilterKey, TRealInclude>}`]?: (
+      filter: TFilter[x extends `${TRealPrefix}${infer K}`
+        ? K extends TFilterKey
+          ? K
+          : x
+        : x],
+      allFilters: any,
+      context: any
+    ) =>
+      | Promise<SqlFragment | null | undefined | false>
+      | SqlFragment
+      | null
+      | undefined
+      | false
+  }
+} & SqlFragment
+
+export const buildView = (
+  parts: readonly string[],
+  ...values: readonly ValueExpression[]
+) => {
+  const fromFragment = sql.fragment(parts, ...values)
+  if (!fromFragment?.sql?.match(/^\s*FROM/i)) {
+    throw new Error('First part of view must be FROM')
+  }
+  const preprocessors = [] as ((filters: any, context: any) => Promise<any> | any)[];
+  const config = {
+    table: fromFragment.sql.match(/^FROM\s*(\w+)/i)?.[1]
+  };
+  if (!config.table) {
+    config.table = fromFragment.sql.match(/(AS|\))\s+(\w+)\s*$/i)?.[2]
+  }
+  if (!config.table) {
+    console.warn(`Could not determine table name for ${fromFragment.sql}. Please use setMainTable() to set the table name manually.`);
+  }
+  const interpreters = {} as Interpretors<Record<string, any>>
+
+  const getWhereConditions = async (
+    filters: RecursiveFilterConditions<any>,
+    context?: any
+  ) => {
+    const postprocessedFilters = await preprocessors.slice(-1).reduce(async (acc, preprocessor) => {
+      const filters = await acc;
+      return preprocessor(filters, context);
+    }, filters);
+    const conditions = await interpretFilter(postprocessedFilters || filters, interpreters as any, context)
+    return conditions;
+  }
+  const getWhereFragment = async (
+    filters: RecursiveFilterConditions<any>,
+    context?: any
+  ) => {
+    const conditions = await getWhereConditions(filters, context)
+    return conditions.length
+      ? sql.fragment`WHERE (${sql.join(conditions, sql.fragment`\n) AND(\n`)})`
+      : sql.fragment``
+  }
+
+  const getFromFragment = () => {
+    // return sql.fragment`${fromFragment} ${await getWhereFragment(args.where, args.ctx)}`
+    return fromFragment;
+  }
+
+  const addFilter = (interpreter: (value: any, field: FragmentSqlToken) => any, fields: string | string[], mapper?: ((table: IdentifierSqlToken, value?: any, allFilters?: any, context?: any) => SqlFragment)) => {
+    if (mapper && Array.isArray(fields) && fields.length > 1) {
+      throw new Error('If you specify a mapper function you cannot have multiple filter keys');
+    }
+    return self.addFilters((Array.isArray(fields) ? fields : [fields]).reduce((acc, key) => {
+      return {
+        ...acc,
+        [key]: (value: any, allFilters: any, ctx: any, key: string) => {
+          const keys = key.split('.');
+          if (keys.length > 2) {
+            // Ignore middle keys (earlier prefixes), only first and last matter
+            keys.splice(1, keys.length - 2);
+          }
+          const identifier = mapper ?
+            // Try to get the table name from the 2nd to last prefix if it exists, if not then use main table
+            mapper(sql.identifier([keys[keys.length - 2] || config.table || '']), value, allFilters, ctx) :
+              config.table && keys.length <= 1 ?
+                (sql.identifier([config.table, ...keys.slice(-1)]) as any) :
+                (sql.identifier([...keys.slice(-2)]) as any)
+          return interpreter(
+            value,
+            identifier,
+          )
+        }
+      }
+    }, {}));
+  }
+  const self = {
+    ...fromFragment,
+    getFromFragment,
+    addFilters(filters: any) {
+      Object.assign(interpreters, filters)
+      return self
+    },
+    setMainTable(newTable: string) {
+      config.table = newTable;
+      return self;
+    },
+    setFilterPreprocess(preprocess: ((filters: any, context: any) => Promise<any> | any)) {
+      preprocessors.push(preprocess);
+      return self;
+    },
+    getFilters(options?: any) {
+      let prefix = options?.table || '';
+      if (prefix && !prefix.endsWith('.')) {
+        prefix += '.';
+      }
+      const exclude = (options?.exclude || []) as string[];
+      const include = (options?.include || []) as string[];
+      const filters = {} as any
+      for (const key of Object.keys(interpreters)) {
+        // exclude may have * wildcards that exclude all filters that start with the prefix
+        if (exclude.some(ex => ex.endsWith('*') ? key.startsWith(ex.replace('*', '')) : ex === key)) {
+          continue;
+        }
+        const isIncluded = !include.length || include.some(ex => ex.endsWith('*') ? key.startsWith(ex.replace('*', '')) : ex === key);
+        if (isIncluded) {
+          filters[prefix + key.replace(prefix, '')] = {
+            interpret: (interpreters as any)[key]?.interpret || (interpreters as any)[key],
+            prefix: key.startsWith(prefix) ? '' : prefix,
+          }
+        }
+      }
+      return filters
+    },
+    addStringFilter: (keys: string | string[], name?: any) => {
+      return addFilter(stringFilter, keys, name);
+    },
+    addComparisonFilter: (keys: string | string[], name?: any) => {
+      return addFilter(comparisonFilter, keys, name);
+    },
+    addBooleanFilter: (keys: string | string[], name?: any) => {
+      return addFilter(booleanFilter, keys, name);
+    },
+    addInArrayFilter: (keys: string | string[], name?: any) => {
+      return addFilter(arrayFilter, keys, name);
+    },
+    addGenericFilter: (name: string, interpret?: any) => {
+      return addFilter(genericFilter, name, (table, value, ...args) => {
+        return interpret(value, ...args);
+      });
+    },
+    getWhereConditions: async (args: any) => {
+      return getWhereConditions(
+        args.where,
+        args.ctx
+      )
+    },
+    getWhereFragment: async (args: any) => {
+      return getWhereFragment(
+        args.where,
+        args.ctx
+      )
+    },
+  }
+  return self as BuildView
+}
+
+export type RecursiveFilterConditions<
+  TFilter,
+  TDisabled extends 'AND' | 'OR' | 'NOT' = never
+> = TFilter &
+  Omit<
+    {
+      AND?: RecursiveFilterConditions<TFilter>[]
+      OR?: RecursiveFilterConditions<TFilter>[]
+      NOT?: RecursiveFilterConditions<TFilter>
+    },
+    TDisabled
+  >
+
+const interpretFilter = async <TFilter extends Record<string, any>>(
+  filter: RecursiveFilterConditions<TFilter>,
+  interpreters: Interpretors<TFilter>,
+  context?: any
+) => {
+  const conditions = [] as SqlFragment[]
+  const addCondition = (item: SqlFragment | null) =>
+    item && conditions.push(item)
+  for (const key of Object.keys(filter)) {
+    const interpreter = interpreters[key as never] as any
+    const condition = await (interpreter?.interpret || interpreter)?.(
+      filter[key as never],
+      filter as TFilter,
+      context,
+      key,
+    )
+    if (condition) {
+      addCondition(condition)
+    }
+  }
+  if (filter.OR?.length) {
+    const orConditions = await Promise.all(
+      filter.OR.map(async or => {
+        const orFilter = await interpretFilter(or, interpreters, context)
+        return orFilter?.length
+          ? sql.fragment`(${sql.join(orFilter, sql.fragment`) AND (`)})`
+          : null
+      })
+    ).then(filters => filters.filter(notEmpty))
+    if (orConditions?.length) {
+      addCondition(
+        sql.fragment`(${sql.join(orConditions, sql.fragment`) OR (`)})`
+      )
+    }
+  }
+  if (filter.AND?.length) {
+    const andConditions = await Promise.all(
+      filter.AND.map(async and => {
+        const andFilter = await interpretFilter(and, interpreters, context)
+        return andFilter?.length
+          ? sql.fragment`(${sql.join(andFilter, sql.fragment`) AND (`)})`
+          : null
+      })
+    ).then(filters => filters.filter(notEmpty))
+    if (andConditions?.length) {
+      addCondition(
+        sql.fragment`(${sql.join(andConditions, sql.fragment`) AND (`)})`
+      )
+    }
+  }
+  if (filter.NOT) {
+    const notFilter = await interpretFilter(filter.NOT, interpreters, context)
+    if (notFilter.length) {
+      addCondition(
+        sql.fragment`NOT (${sql.join(notFilter, sql.fragment`) AND (`)})`
+      )
+    }
+  }
+
+  return conditions
+}

--- a/src/core/buildView.ts
+++ b/src/core/buildView.ts
@@ -394,11 +394,6 @@ export const buildView = (
     if (!config.table) {
         config.table = fromFragment.sql.match(/(AS|\))\s+(\w+)\s*$/i)?.[2];
     }
-    if (!config.table) {
-        console.warn(
-            `Could not determine table name for ${fromFragment.sql}. Please use setAliases({ _main: 'tableName' }) to set the table name manually.`
-        );
-    }
     const interpreters = {} as Interpretors<Record<string, any>>;
 
     const getWhereConditions = async (

--- a/src/core/makeQueryLoader.ts
+++ b/src/core/makeQueryLoader.ts
@@ -823,11 +823,7 @@ export function makeQueryLoader<
                 }
             }
             const load = () => db.any(finalQuery).then(async rows => {
-                return mapTransformRows(reverse ? (rows as any).reverse() as never : rows, {
-                    // Backwards compatible with ctx
-                    ...args.ctx,
-                    ...args,
-                });
+                return mapTransformRows(reverse ? (rows as any).reverse() as never : rows, args);
             }).then(async rows => {
                 // Call the onLoadDone method of each plugin
                 for (const onLoadDone of afterCalls) {

--- a/src/core/queryFilter.ts
+++ b/src/core/queryFilter.ts
@@ -19,36 +19,6 @@ export type RecursiveFilterConditions<TFilter, TDisabled extends "AND" | "OR" | 
     NOT?: RecursiveFilterConditions<TFilter>;
 }, TDisabled>;
 
-type ZodRecursiveFilterConditions<TFilter extends Record<string, z.ZodType>> =
-    TFilter & {
-        AND: z.ZodOptional<
-            z.ZodArray<z.ZodObject<ZodRecursiveFilterConditions<TFilter>>>
-        >;
-        OR: z.ZodOptional<
-            z.ZodArray<z.ZodObject<ZodRecursiveFilterConditions<TFilter>>>
-        >;
-        NOT: z.ZodOptional<z.ZodObject<ZodRecursiveFilterConditions<TFilter>>>;
-    };
-
-export const recursiveFilterConditions = <
-    TFilter extends Record<string, z.ZodType>,
->(
-    filter: TFilter,
-    disabledFilters?: {
-        [x in "AND" | "OR" | "NOT"]?: boolean
-    },
-): z.ZodObject<ZodRecursiveFilterConditions<TFilter>> => {
-    const filterType: any = z.lazy(() =>
-        z.object({
-            ...filter,
-            ...(!disabledFilters?.OR && { OR: z.array(filterType) }),
-            ...(!disabledFilters?.AND && { AND: z.array(filterType) }),
-            ...(!disabledFilters?.NOT && { NOT: filterType }),
-        }).partial()
-    );
-    return filterType;
-};
-
 export type ZodPartial<TFilter extends Record<string, z.ZodType>> =
     z.ZodOptional<
         z.ZodObject<{

--- a/src/helpers/__tests__/sqlUtils.test.ts
+++ b/src/helpers/__tests__/sqlUtils.test.ts
@@ -112,6 +112,29 @@ describe("Query builders", () => {
         }]);
     });
 
+    it("Selects nested rows to array", async () => {
+        const result = await db.any(sql.unsafe`SELECT ${
+            rowsToArray(
+                sql.fragment`SELECT
+                    ${rowsToArray(
+                        sql.fragment`SELECT email`,
+                        sql.fragment`FROM users`,
+                        'emails'
+                    )}
+                , date_of_birth`,
+                sql.fragment`FROM users`,
+            )
+        }`);
+        expect(result).toEqual([{
+            users: expect.arrayContaining([{
+                emails: expect.arrayContaining([{
+                    email: expect.any(String),
+                }]),
+                date_of_birth: expect.any(String),
+            }])
+        }]);
+    });
+
     it("Selects row to object", async () => {
         const result = await db.any(sql.unsafe`SELECT ${
             rowToJson(

--- a/src/helpers/__tests__/sqlUtils.test.ts
+++ b/src/helpers/__tests__/sqlUtils.test.ts
@@ -44,6 +44,8 @@ describe('Filters', () => {
         expect(dateFilter({}, sql.fragment`test`)).toBeNull();
         expect(dateFilter({ _gt: '2021-01-01' }, sql.fragment`test`)).toEqual(sql.fragment`(test > ${'2021-01-01'})`);
         expect(dateFilter({ _lt: '2021-01-01' }, sql.fragment`test`)).toEqual(sql.fragment`(test < ${'2021-01-01'})`);
+        expect(dateFilter({ _gte: '2021-01-01' }, sql.fragment`test`)).toEqual(sql.fragment`(test >= ${'2021-01-01'})`);
+        expect(dateFilter({ _lte: '2021-01-01' }, sql.fragment`test`)).toEqual(sql.fragment`(test <= ${'2021-01-01'})`);
         expect(dateFilter({ _gt: '2021-01-01', _lt: '2021-01-02' }, sql.fragment`test`)).toEqual(sql.fragment`(test > ${'2021-01-01'}) AND (test < ${'2021-01-02'})`);
     });
     it("Boolean filter", () => {
@@ -58,6 +60,8 @@ describe('Filters', () => {
         expect(comparisonFilter(undefined, sql.fragment`test`)).toBeNull();
         expect(comparisonFilter(comparisonFilterType.parse({ _gt: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test > ${'1'})`);
         expect(comparisonFilter(comparisonFilterType.parse({ _lt: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test < ${'1'})`);
+        expect(comparisonFilter(comparisonFilterType.parse({ _gte: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test >= ${'1'})`);
+        expect(comparisonFilter(comparisonFilterType.parse({ _lte: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test <= ${'1'})`);
         expect(comparisonFilter(comparisonFilterType.parse({ _neq: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test != ${'1'})`);
         expect(comparisonFilter(comparisonFilterType.parse({ _eq: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test = ${'1'})`);
         expect(comparisonFilter(comparisonFilterType.parse({ _in: ['1', '2'] }), sql.fragment`test`)).toEqual(sql.fragment`(test = ANY(${sql.array(['1', '2'], 'text')}))`);
@@ -69,6 +73,7 @@ describe('Filters', () => {
     it("String filter", () => {
         expect(stringFilter(null, sql.fragment`test`)).toBeNull();
         expect(stringFilter(undefined, sql.fragment`test`)).toBeNull();
+        expect(stringFilter(stringFilterType.parse('textString'), sql.fragment`test`)).toEqual(sql.fragment`(test = ${'textString'})`);
         expect(stringFilter(stringFilterType.parse({ _in: ['1', '2'] }), sql.fragment`test`)?.sql).toMatch(sql.fragment`(test = ANY(${sql.array(['1', '2'], 'text')}))`.sql);
         expect(stringFilter(stringFilterType.parse({ _like: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test LIKE ${'1'})`);
         expect(stringFilter(stringFilterType.parse({ _ilike: '1' }), sql.fragment`test`)).toEqual(sql.fragment`(test ILIKE ${'1'})`);
@@ -97,7 +102,6 @@ describe("Query builders", () => {
             rowsToArray(
                 sql.fragment`SELECT email, date_of_birth`,
                 sql.fragment`FROM users`,
-                'users'
             )
         }`);
         expect(result).toEqual([{

--- a/src/helpers/sqlUtils.ts
+++ b/src/helpers/sqlUtils.ts
@@ -92,17 +92,19 @@ export const dateFilter = (
     return null;
 };
 
-export const arrayFilter = (
+export const arrayDynamicFilter = (type = 'text') => (
     filter: string[] | number[] | string | number | undefined | null,
     field: Fragment,
-    type = 'text'
+    typeOverride?: string
 ) => {
     if (!Array.isArray(filter)) filter = [filter].filter(notEmpty) as string[];
     if (filter?.length) {
-        return sql.fragment`${field} = ANY(${sql.array(filter, type)})`;
+        return sql.fragment`${field} = ANY(${sql.array(filter, typeOverride || type)})`;
     }
     return null;
 };
+
+export const arrayFilter = arrayDynamicFilter();
 
 export const invertFilter = (condition?: Fragment | null) => {
     if (condition) {

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,7 +1,7 @@
-import type { QuerySqlToken, FragmentSqlToken } from 'slonik';
+import type { QuerySqlToken, FragmentSqlToken, SerializableValue } from 'slonik';
 
 export type Fragment = FragmentSqlToken;
-export type { QuerySqlToken  as Query };
+export type { QuerySqlToken  as Query, SerializableValue };
 
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -1,6 +1,6 @@
-import { sql, QuerySqlToken } from 'slonik';
+import type { QuerySqlToken, FragmentSqlToken } from 'slonik';
 
-export type Fragment = ReturnType<typeof sql["fragment"]>;
+export type Fragment = FragmentSqlToken;
 export type { QuerySqlToken  as Query };
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,5 @@ export const createOptions: ReturnFirstArgument<typeof makeQueryLoader> = ((opti
 });
 
 export type { Plugin } from './core/plugins/types';
+
+export { buildView } from './core/buildView';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,5 @@ export const createOptions: ReturnFirstArgument<typeof makeQueryLoader> = ((opti
 export type { Plugin } from './core/plugins/types';
 
 export { buildView } from './core/buildView';
+
+export { sql } from 'slonik';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export {
 } from './core/makeQueryLoader';
 
 type ReturnFirstArgument<T> = T extends (...args: readonly [(infer A)]) => any ? <G extends A=A>(...args: readonly [G]) => G : T;
+
+export type LoaderOptions = Parameters<typeof makeQueryLoader>[0];
 export const createOptions: ReturnFirstArgument<typeof makeQueryLoader> = ((options) => {
     return options;
 });


### PR DESCRIPTION
Added `buildView` function to simplify filter declaration.

The goal is to reuse these filters across different query loaders, even when the FROM relations are different, as long as they have the same basic dependencies.

This enhances the composability and reusability of filter declarations